### PR TITLE
Docker, tileserver | add simple tileserver wit low-detail world map

### DIFF
--- a/docker/.gitignore
+++ b/docker/.gitignore
@@ -2,3 +2,4 @@
 .env
 # container's volume
 postgres/
+tilesets/

--- a/docker/README.md
+++ b/docker/README.md
@@ -58,7 +58,6 @@ docker compose up --scale tileserver=1 --build --no-deps --force-recreate
 ```
 
 ### Usage
-On Linux, ensure that XServer and Xhost installed and run the following command to give docker access to graphics server:
 
 Tiles are provided at:
 ```

--- a/docker/README.md
+++ b/docker/README.md
@@ -33,6 +33,43 @@ sudo rm -rf ./postgres
 docker compose up --build --no-deps --force-recreate
 ```
 
+## Database, api-server and map tileserver:
+
+### Prerequisites:
+
+Run the following command from `./docker` directory to download map tiles:
+
+```bash
+mkdir ./tilesets
+wget https://ftp.gwdg.de/pub/misc/openstreetmap/openandromaps/world/OAM-World-1-8-min-J80.zip
+unzip OAM-World-1-8-min-J80.zip -d ./tilesets
+rm OAM-World-1-8-min-J80.zip
+```
+
+### Running
+
+
+```bash
+docker compose up --scale tileserver=1
+```
+or
+```bash
+docker compose up --scale tileserver=1 --build --no-deps --force-recreate
+```
+
+### Usage
+On Linux, ensure that XServer and Xhost installed and run the following command to give docker access to graphics server:
+
+Tiles are provided at:
+```
+<host>:<port>/services/<tileset_id>/tiles/{z}/{x}/{y}.<format>
+```
+From host machine:
+```
+http://localhost:8082/services/OAM-World-1-8-min-J80/tiles/{z}/{x}/{y}.jpg
+```
+
+
 ## Database, api-server and GUI (Temporally disabled)
 
 It is also possible to run app with GUI by replacing the commands above with:

--- a/docker/api-server/Dockerfile
+++ b/docker/api-server/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.80.1 as builder
+FROM rust:1.86.0 as builder
 RUN apt update
 # compile the api-server binary executable
 WORKDIR /app

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -28,6 +28,20 @@ services:
     networks:
       - api-server
 
+  tileserver:
+    deploy:
+      replicas: 0
+    image: ghcr.io/consbio/mbtileserver:latest
+    restart: unless-stopped
+    environment:
+      - PORT=8000
+    volumes:
+      - ./tilesets:/tilesets:ro
+    ports:
+      - 8082:8000
+    networks:
+      - api-server
+
   # client:
   #   build:
   #     context: ./client


### PR DESCRIPTION
Add [container](https://hub.docker.com/r/consbio/mbtileserver) with [low-detail map](https://www.openandromaps.org/en/downloads/general-maps) and simple tileserver that uses [Slippy](https://wiki.openstreetmap.org/wiki/Slippy_map_tilenames) protocol 